### PR TITLE
Fixed text color when default color is changed

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -7,11 +7,13 @@
     --primary-color: #3b67a0;
     --light: #b1b1b1;
     --background: rgb(249, 249, 250);
+    --text-color: rgb(0, 0, 0);
 }
 
 body {
     font-size: .9rem;
     background: var(--background);
+    color: var(--text-color);
 }
 
 #rulesTab * + * {

--- a/src/popup/browser-action.css
+++ b/src/popup/browser-action.css
@@ -4,6 +4,7 @@
 
 html, body {
     height: 100%;
+    color: #000000;
 }
 
 body {


### PR DESCRIPTION
For the configuration page and the pop-up the background color was
defined only. Now the text color is defined too so the text can be
easily read even when the default color was changed in the Preferences
of Firefox to black background and white text.