### PR TITLE
Tweaks

### DIFF
--- a/rules/privacy-amazon.json
+++ b/rules/privacy-amazon.json
@@ -14,7 +14,7 @@
                 "*"
             ],
             "excludes": [
-              "://www.amazon.*/ap/cnep*",
+              "://www.amazon.*/ap/*",
               "://www.amazon.*/gp/*"
             ],
             "topLevelDomains": [

--- a/rules/privacy-common-images.json
+++ b/rules/privacy-common-images.json
@@ -524,7 +524,8 @@
     "pattern": {
       "scheme": "*",
       "host": [
-        "*.fna.fbcdn.net"
+        "*.fna.fbcdn.net",
+        "*.xx.fbcdn.net"
       ],
       "path": [
         "static_map.php?*"

--- a/rules/privacy-common-images.json
+++ b/rules/privacy-common-images.json
@@ -28,7 +28,8 @@
     "action": "filter",
     "active": true,
     "types": [
-      "image"
+      "image",
+      "media"
     ],
     "paramsFilter": {
       "values": [
@@ -166,7 +167,8 @@
       ]
     },
     "types": [
-      "image"
+      "image",
+      "media"
     ],
     "action": "filter",
     "active": true,
@@ -211,7 +213,8 @@
       ]
     },
     "types": [
-      "image"
+      "image",
+      "media"
     ],
     "action": "filter",
     "active": true,
@@ -243,7 +246,8 @@
       ]
     },
     "types": [
-      "image"
+      "image",
+      "media"
     ],
     "action": "filter",
     "active": true,

--- a/rules/privacy-common-images.json
+++ b/rules/privacy-common-images.json
@@ -69,6 +69,7 @@
         "image",
         "imagesr",
         "inputformat",
+        "label",
         "latex",
         "layer",
         "layers",

--- a/rules/privacy-common-images.json
+++ b/rules/privacy-common-images.json
@@ -18,7 +18,7 @@
         "/:\\/\\/[a-z]{3,4}[0123]?\\.(google|googleapis|ggpht)\\.com\\/(maps\\/vt|cbk|kh)\\?/",
         "/\\/(Satellite|BlobServer|StaticBS)(\\/[^\\/\\?]+)?\\?/",
         "/\\/(ap_resize\\/ap_resize|image|imageproxy|resizer\\/resizer|safe_image)(.php)?\\?/",
-        "/\\/(i|fetch|image_gallery|thumb)(\\.php|\\/)?\\?/",
+        "/\\/(i|fetch|image_gallery|thumb|thumbnail)(\\.php|\\/)?\\?/",
         "/\\?.*\\&(_nc_[a-z]{1,3}|oh|oe)=./",
         "://c.disquscdn.com/get?url=",
         "://web.whatsapp.com/pp",
@@ -122,7 +122,7 @@
         "*"
       ],
       "includes": [
-        "/\\/(i|fetch|image_gallery|thumb)(\\.php|\\/)?\\?/"
+        "/\\/(i|fetch|image_gallery|thumb|thumbnail)(\\.php|\\/)?\\?/"
       ]
     },
     "types": [
@@ -142,6 +142,7 @@
         "image_path",
         "img_id",
         "imgid",
+        "submissionId",
         "t",
         "uuid",
         "version",
@@ -150,7 +151,7 @@
       "invert": true
     },
     "tag": "filter-images-2",
-    "description": "Undocumented image-selection PHP scripts, based in numeric IDs."
+    "description": "Several image selection PHP scripts, based in numeric IDs."
   },
   {
     "uuid": "71bc39c3-0a9e-44ef-8309-bcdb99377491",

--- a/rules/privacy-common-params.json
+++ b/rules/privacy-common-params.json
@@ -104,24 +104,5 @@
         "title": "Exceptions to `sid` and `share` parameters",
         "description": "These sites use the URL parameters `sid` and `share` to load different pages. This trips a general-purpose referrer remover.",
         "tag": "whitelist-utm"
-    },
-    {
-        "uuid": "953324d7-0aff-48c0-96fc-b4b746befa7e",
-        "pattern": {
-            "scheme": "https",
-            "host": [
-                "www.linkedin.com"
-            ],
-            "path": [
-                "/checkpoint/rp/request-password-reset-submit-redir-email-pin?*"
-            ]
-        },
-        "types": [
-            "main_frame"
-        ],
-        "action": "whitelist",
-        "active": true,
-        "title": "Restore password reset at LinkedIn",
-        "tag": "whitelist-linkedin-password-reset"
     }
 ]

--- a/rules/privacy-common-redirectors.json
+++ b/rules/privacy-common-redirectors.json
@@ -1,7 +1,7 @@
 [
     {
         "title": "Skip external dereferrers and redirectors",
-        "description": "This filter is applied globally by URL path. As matched globally, it may result in a site from not functioning correctly. Disabled by default.",
+        "description": "This filter is applied globally by URL path. As matched globally, it may result in a site not functioning correctly. Disabled by default.",
         "tag": "filter-common",
         "uuid": "4a6b8caf-3d0b-4c95-876e-b2cdcde1eb6a",
         "pattern": {

--- a/rules/privacy-linkedin.json
+++ b/rules/privacy-linkedin.json
@@ -12,6 +12,7 @@
             "excludes": [
                 "/\\/checkpoint\\//",
                 "/\\/jobs\\/\\?/",
+                "/\\/login\\?/",
                 "/\\/oauth\\/v2\\//",
                 "/\\/search\\/\\?/",
                 "/\\/uas\\/login\\?/",


### PR DESCRIPTION
Several tweaks to rulesets to cover some border cases and more configuration/login pages at Amazon and LinkedIn. I forgot where did I encounter the URL parameter `label`; it probably wasn't especially important, but it left a hole in the page and seems innocuous enough.

I deleted the whitelist rule for LinkedIn because that case is already covered with the filter at `rules/privacy-linkedin.json`.