### PR TITLE
Create privacy-qwant-lite.json

### DIFF
--- a/rules/privacy-qwant-lite.json
+++ b/rules/privacy-qwant-lite.json
@@ -1,0 +1,22 @@
+[
+  {
+    "title": "Skip Qwant Lite redirect",
+    "description": "Skip Qwant Lite redirect in search results",
+    "uuid": "62b1a6c1-76ea-43c1-9d4d-dde55d5855e9",
+    "pattern": {
+      "scheme": "*",
+      "host": [
+        "lite.qwant.com"
+      ],
+      "path": [
+        "redirect/*"
+      ]
+    },
+    "types": [
+      "main_frame"
+    ],
+    "action": "redirect",
+    "active": true,
+    "redirectUrl": "{pathname/\\/redirect\\/[A-Za-z0-9]+==\\//|decodeBase64|decodeURIComponent}"
+  }
+]


### PR DESCRIPTION
If you search on qwant lite for e.g. RequestControl (`https://lite.qwant.com/?q=RequestControl`), all search results are redirect links. So instead of https://github.com/tumpio/requestcontrol you get

```
https://lite.qwant.com/redirect/NWY1ZGYyNjA0ZWI0M2RjMTZmNzZiNmU5NzI1YWY1MDcxYzFhOTQwNDcxMmJiYWE5ZGQzNWVjYTIyYmExYWNiMg==/aHR0cHMlM0ElMkYlMkZnaXRodWIuY29tJTJGdHVtcGlvJTJGcmVxdWVzdGNvbnRyb2w=?position=3&serp_position=3&t=web&locale=de_de&query=RequestControl&ad=0&uri=%2F%3Fq%3DRequestControl&cacheKey=i9ffef1df5a8076e0962d1edf9820e8fd
```

If you decode `NWY1ZGYyNjA0ZWI0M2RjMTZmNzZiNmU5NzI1YWY1MDcxYzFhOTQwNDcxMmJiYWE5ZGQzNWVjYTIyYmExYWNiMg==`, you get `5f5df2604eb43dc16f76b6e9725af5071c1a9404712bbaa9dd35eca22ba1acb2`. Which looks like a sha256sum but I couldn't find which data is hashed.

`aHR0cHMlM0ElMkYlMkZnaXRodWIuY29tJTJGdHVtcGlvJTJGcmVxdWVzdGNvbnRyb2w=` (the filename of the url) is
```
base64:encodeURIComponent:https://github.com/tumpio/requestcontrol
```

The query part contains the `position` in the results, the search type (e.g. web, image, ...), the locale, the search query and the search uri (without protocol and domain).

The official justification is to strip the referer IIRC (I could find any) and that no data is collected/stored. However users might still want to skip this redirection. Sometimes the qwant servers have errors and don't allow you to visit a result or are down and I also saw issues with TemporaryContainers in automatic mode.